### PR TITLE
chore: replace `latest` ranges with caret ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
     "test:types": "tsc --noEmit"
   },
   "devDependencies": {
-    "@antfu/eslint-config": "latest",
-    "@types/node": "latest",
-    "@vitest/coverage-v8": "latest",
-    "eslint": "latest",
+    "@antfu/eslint-config": "^9.1.0",
+    "@types/node": "^26.1.0",
+    "@vitest/coverage-v8": "^4.1.9",
+    "eslint": "^10.6.0",
     "nano-staged": "1.0.2",
-    "simple-git-hooks": "latest",
+    "simple-git-hooks": "^2.13.1",
     "tsdown": "0.22.3",
-    "typescript": "latest",
-    "vite": "latest",
-    "vitest": "latest"
+    "typescript": "^6.0.3",
+    "vite": "^8.1.3",
+    "vitest": "^4.1.9"
   },
   "simple-git-hooks": {
     "pre-commit": "npx nano-staged"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,34 +12,34 @@ importers:
   .:
     devDependencies:
       '@antfu/eslint-config':
-        specifier: latest
+        specifier: ^9.1.0
         version: 9.1.0(@typescript-eslint/rule-tester@8.60.1(eslint@10.6.0)(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.62.0(typescript@6.0.3))(@typescript-eslint/utils@8.62.0(eslint@10.6.0)(typescript@6.0.3))(@vue/compiler-sfc@3.4.38)(eslint@10.6.0)(typescript@6.0.3)(vitest@4.1.9)
       '@types/node':
-        specifier: latest
+        specifier: ^26.1.0
         version: 26.1.0
       '@vitest/coverage-v8':
-        specifier: latest
+        specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
       eslint:
-        specifier: latest
+        specifier: ^10.6.0
         version: 10.6.0
       nano-staged:
         specifier: 1.0.2
         version: 1.0.2
       simple-git-hooks:
-        specifier: latest
+        specifier: ^2.13.1
         version: 2.13.1
       tsdown:
         specifier: 0.22.3
         version: 0.22.3(typescript@6.0.3)
       typescript:
-        specifier: latest
+        specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: latest
+        specifier: ^8.1.3
         version: 8.1.3(@types/node@26.1.0)(yaml@2.9.0)
       vitest:
-        specifier: latest
+        specifier: ^4.1.9
         version: 4.1.9(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.1.3(@types/node@26.1.0)(yaml@2.9.0))
 
   playground:
@@ -1665,10 +1665,6 @@ packages:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2721,7 +2717,7 @@ snapshots:
       '@vue/shared': 3.4.38
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.15
+      postcss: 8.5.16
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.4.38':
@@ -3795,12 +3791,6 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.16:
     dependencies:


### PR DESCRIPTION
`latest` is a curse and can easily drift, or change wildly on lockfile regeneration